### PR TITLE
Port to hsyslog version 5.

### DIFF
--- a/hdaemonize.cabal
+++ b/hdaemonize.cabal
@@ -21,7 +21,7 @@ Library
   Build-Depends:    base >= 4 && < 5
                   , bytestring
                   , unix
-                  , hsyslog == 4
+                  , hsyslog == 5.*
                   , extensible-exceptions
                   , filepath
                   , mtl


### PR DESCRIPTION
Addresses https://github.com/fpco/stackage/issues/2513. Note that the use of `unsafeUseAsCStringLen` is (a) perfectly safe and (b) makes logging more efficient than it used to be in previous versions of the API since we take advantage of the fact that `ByteString` can be used by the C function call without any conversion since it's a C string anyway.